### PR TITLE
Use a different PhantomJS bridge

### DIFF
--- a/example/basic/index.js
+++ b/example/basic/index.js
@@ -14,7 +14,7 @@ truffler({
 				/* global document */
 				return document.title;
 			},
-			function (result) {
+			function (err, result) {
 				done(null, result);
 			}
 		);

--- a/example/multiple/index.js
+++ b/example/multiple/index.js
@@ -15,7 +15,7 @@ truffler({
 				/* global document */
 				return document.title;
 			},
-			function (result) {
+			function (err, result) {
 				done(null, result);
 			}
 		);

--- a/lib/truffler.js
+++ b/lib/truffler.js
@@ -2,7 +2,7 @@
 
 var extend = require('node.extend');
 var hasbin = require('hasbin');
-var phantom = require('phantom');
+var phantom = require('node-phantom-simple');
 var pkg = require('../package.json');
 
 module.exports = truffler;
@@ -36,7 +36,7 @@ function truffler (options, completeSetup) {
 		if (error) {
 			return completeSetup(error);
 		}
-		phantom.create(function (browser) {
+		phantom.create(function (err, browser) {
 			options.log.info('PhantomJS browser created');
 			completeSetup(
 				null,
@@ -59,10 +59,10 @@ function testUrl (options, browser, url, completeTest) {
 		url = 'http://' + url;
 	}
 	options.log.info('Testing page: "' + url + '"');
-	browser.createPage(function (page) {
+	browser.createPage(function (err, page) {
 		options.log.debug('PhantomJS page created for "' + url + '"');
 		configurePage(page, options.page);
-		page.open(url, function (status) {
+		page.open(url, function (err, status) {
 			if (status !== 'success') {
 				var error = new Error('Page "' + url + '" could not be loaded');
 				options.log.error('PhantomJS failed to open "' + url + '"');

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
 	"dependencies": {
 		"hasbin": "~0.2",
 		"node.extend": "~1.1",
-		"phantom": "~0.7"
+		"node-phantom-simple": "^1.2.0"
 	},
 	"devDependencies": {
 		"async": "~0.9",

--- a/test/integration/tests.js
+++ b/test/integration/tests.js
@@ -25,7 +25,7 @@ describe('Truffler Example Application', function () {
 							body: document.body.textContent
 						};
 					},
-					function (result) {
+					function (err, result) {
 						completeTest(null, result);
 					}
 				);

--- a/test/unit/lib/truffler.js
+++ b/test/unit/lib/truffler.js
@@ -18,7 +18,7 @@ describe('lib/truffler', function () {
 		mockery.registerMock('hasbin', hasbin);
 
 		phantom = require('../mock/phantom');
-		mockery.registerMock('phantom', phantom);
+		mockery.registerMock('node-phantom-simple', phantom);
 
 		pkg = require('../../../package.json');
 

--- a/test/unit/mock/phantom.js
+++ b/test/unit/mock/phantom.js
@@ -15,6 +15,6 @@ var phantom = module.exports = {
 	}
 };
 
-phantom.create.yieldsAsync(phantom.mockBrowser);
-phantom.mockBrowser.createPage.yieldsAsync(phantom.mockPage);
-phantom.mockPage.open.yieldsAsync('success');
+phantom.create.yieldsAsync(null, phantom.mockBrowser);
+phantom.mockBrowser.createPage.yieldsAsync(null, phantom.mockPage);
+phantom.mockPage.open.yieldsAsync(null, 'success');


### PR DESCRIPTION
A bit of follow up from nature/pa11y#73.

This is a demo of another PhantomJS bridge. [baudehlo/node-phantom-simple](https://github.com/baudehlo/node-phantom-simple) was one of the first things I could find on npm—I am not saying that it's perfect, just that it's another option.

I think there could be two main benefits:

- Windows support (this one does not depend on native compilation)
- Less orphaned processes (possibly)

From a quick test (super not-scientific), it doesn't orphan PhantomJS when the node process dies. From a cursory look through the source it seems that while both libs spawn child processes, `node-phantom-simple` [registers an `uncaughtException` handler](https://github.com/baudehlo/node-phantom-simple/blob/703f8163ae6e4b1e33773a2cadd0daedbe0a6d08/node-phantom-simple.js#L91-L115) (?).

This is less an actual merge proposal, more a question with code: would this work?