### PR TITLE
Support Node.js 4.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,36 @@
 
-# Language/versions
+# Build matrix
 language: node_js
-node_js:
-  - "0.12"
-  - "0.10"
+matrix:
+  include:
+
+    # Run tests in Node.js 0.10
+    - node_js: '0.10'
+
+    # Run tests in Node.js 0.12
+    - node_js: '0.12'
+
+    # Run tests in Node.js 4.x (dependencies require GCC 4.8)
+    - node_js: '4'
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - gcc-4.8
+            - g++-4.8
+
+# Restrict builds on branches
+branches:
+  only:
+    - master
+    - /^\d+\.\d+\.\d+$/
+
+# Before install
+before_install:
+  # Use GCC 4.8 if it's available
+  - 'if [ ! `which gcc-4.8` == "" ]; then export CXX=g++-4.8 && export CC=gcc-4.8; fi'
 
 # Build script
-script: make ci
-
-# Notifications
-notifications:
-  email:
-    - j.robinson@nature.com
-    - rowan.manning@nature.com
-  slack: thefeds:vG3hLYB07EwTYpQFp3TNUx82
+script:
+  - make ci

--- a/README.md
+++ b/README.md
@@ -275,6 +275,6 @@ Copyright &copy; 2015, Nature Publishing Group
 [info-build]: https://travis-ci.org/nature/truffler
 [shield-dependencies]: https://img.shields.io/gemnasium/nature/truffler.svg
 [shield-license]: https://img.shields.io/badge/license-MIT-blue.svg
-[shield-node]: https://img.shields.io/node/v/truffler.svg?label=node.js+support
+[shield-node]: https://img.shields.io/badge/node.js%20support-0.10–4-brightgreen.svg
 [shield-npm]: https://img.shields.io/npm/v/truffler.svg
 [shield-build]: https://img.shields.io/travis/nature/truffler/master.svg

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
 	"dependencies": {
 		"hasbin": "~1.1",
 		"node.extend": "~1.1",
-		"phantom": "~0.7"
+		"phantom": "~0.8"
 	},
 	"devDependencies": {
 		"async": "^1",


### PR DESCRIPTION
This adds Node.js 4.x support. Like Shunter, we have to install GCC 4.8 to get the dependencies installing. Hopefully we won't need to do this any more if we adopt an alternative PhantomJS bridge (see #2)